### PR TITLE
$header typo

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -28,7 +28,7 @@ class JWT
     {
         $header = [
             'alg' => 'ES256',
-            'typ' => 'JTW',
+            'typ' => 'JWT',
             'kid' => $key_id
         ];
         $body = [


### PR DESCRIPTION
This typo was causing token generation to fail.

Thanks for this library 👍 